### PR TITLE
* avoid conflit of packages from ARC-CE 5.X and ARC-CE 6.X

### DIFF
--- a/roles/release-candidate/files/conflict.umd.pkgs
+++ b/roles/release-candidate/files/conflict.umd.pkgs
@@ -1,3 +1,15 @@
 dmlite-dpmdisk-domeonly
 dmlite-dpmhead-domeonly
 dmlite-libs
+globus-usage
+globus-usage-devel
+nordugrid-arc-acix-cache
+nordugrid-arc-aris
+nordugrid-arc-cache-service
+nordugrid-arc-egiis
+nordugrid-arc-gridmap-utils
+nordugrid-arc-java
+nordugrid-arc-ldap-infosys
+nordugrid-arc-ldap-monitor
+nordugrid-arc-misc-utils
+nordugrid-arc-ws-monitor

--- a/roles/release-candidate/files/exclude.pkgs
+++ b/roles/release-candidate/files/exclude.pkgs
@@ -29,3 +29,4 @@ lfc-python
 nordugrid-arc-python
 xrootd-python
 cvmfs-config-default
+python3-xroot 


### PR DESCRIPTION
* exclude pyhton3-xroot replaced by python34-xroot